### PR TITLE
Add recursive optgroup support for ingredient menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,21 +333,28 @@
                         return;
                     }
 
-                    data['ingredients'].forEach(item => {
-                        if (item.hasOwnProperty('entries')) {
-                            item['entries'].forEach(entry => {
+                    // Remove existing dynamically added nodes but keep the first option
+                    while (select.children.length > 1) {
+                        select.removeChild(select.lastChild);
+                    }
+
+                    function addItems(parentEl, items) {
+                        items.forEach(item => {
+                            if (item.hasOwnProperty('entries')) {
+                                const group = document.createElement('optgroup');
+                                group.label = item['name'];
+                                addItems(group, item['entries']);
+                                parentEl.appendChild(group);
+                            } else {
                                 const opt = document.createElement('option');
-                                opt.value = entry['name'];
-                                opt.textContent = entry['name'];
-                                select.appendChild(opt);
-                            });
-                        } else {
-                            const opt = document.createElement('option');
-                            opt.value = item['name'];
-                            opt.textContent = item['name'];
-                            select.appendChild(opt);
-                        }
-                    });
+                                opt.value = item['name'];
+                                opt.textContent = item['name'];
+                                parentEl.appendChild(opt);
+                            }
+                        });
+                    }
+
+                    addItems(select, data['ingredients']);
                 })
                 .catch(error => {
                     console.error('Failed to load data:', error);


### PR DESCRIPTION
## Summary
- keep ingredient hierarchy when loading preset ingredient list
- remove any previous dropdown items before populating
- recursively add `optgroup` elements so nested groups appear as sub menus

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845c7f6637c8320ab7c08842844fb84